### PR TITLE
Fixed right stick Y axis for Logitech controllers on Webkit

### DIFF
--- a/gamepad.js
+++ b/gamepad.js
@@ -187,7 +187,7 @@ Gamepad.Mapping = {
 			LEFT_STICK_X: 0,
 			LEFT_STICK_Y: 1,
 			RIGHT_STICK_X: 2,
-			RIGHT_STICK_Y: 5
+			RIGHT_STICK_Y: 3
 		}
 	},
 	XBOX: {


### PR DESCRIPTION
The Y axis was mapped to axis 5 when it should have been 3.
