### PR TITLE
Added Button up and Button down events to Gamepad

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,9 +63,19 @@
 				for (control in gamepads[i].state) {
 					value = gamepads[i].state[control];
 					
+					
+					
 					$('#state-' + gamepads[i].index + '-' + control + '').html(value);
 				}
 			}
+		});
+
+		gamepad.bind(Gamepad.Event.BUTTON_DOWN, function(data) {
+			console.log('pad index:' + data.gamepadIndex + ' button:' + data.control + ' down');
+		});
+		
+		gamepad.bind(Gamepad.Event.BUTTON_UP, function(data) {
+			console.log('pad index:' + data.gamepadIndex + ' button:' + data.control + ' up');
 		});
 
 		if (!gamepad.init()) {


### PR DESCRIPTION
Button up and button down events offer an alternative to polling the gamepad, the changes are as follows:

Added BUTTON_UP and BUTTON_DOWN events to Gamepad.Event
Added a previous state to the gamepad object
Added logic to _update to fire events when states change on the buttons
Added a couple of event handler bindings to index.html to demo functionality
