### PR TITLE
Support for XBOX 360 controllers without "xbox" in ID and XBOX center button

### DIFF
--- a/gamepad.js
+++ b/gamepad.js
@@ -219,7 +219,8 @@ Gamepad.Mapping = {
 			DPAD_UP: 12,
 			DPAD_DOWN: 13,
 			DPAD_LEFT: 14,
-			DPAD_RIGHT: 15
+			DPAD_RIGHT: 15,
+      XBOX: 16
 		},
 		axes: {
 			LEFT_STICK_X: 0,
@@ -462,7 +463,7 @@ Gamepad.prototype._resolveControllerType = function(id) {
 		|| id.indexOf('wireless gamepad') !== -1
 	) {
 		return Gamepad.Type.LOGITECH;
-	} else if (id.indexOf('xbox') !== -1) {
+	} else if (id.indexOf('xbox') !== -1 || id.indexOf('360') !== -1) {
 		return Gamepad.Type.XBOX;
 	} else {
 		return Gamepad.Type.UNSUPPORTED;

--- a/gamepad.js
+++ b/gamepad.js
@@ -220,7 +220,7 @@ Gamepad.Mapping = {
 			DPAD_DOWN: 13,
 			DPAD_LEFT: 14,
 			DPAD_RIGHT: 15,
-      XBOX: 16
+      HOME: 16
 		},
 		axes: {
 			LEFT_STICK_X: 0,


### PR DESCRIPTION
This change adds support for XBOX 360 controllers which do not have the "xbox" string in their IDs, as well as support for the XBOX center button. I have an XBOX 360 wireless controller which does not have "xbox" explicitly in its ID, this allows it to work with your library.
