### PR TITLE
Adding unbind function for events

### DIFF
--- a/gamepad.js
+++ b/gamepad.js
@@ -280,6 +280,19 @@ Gamepad.prototype.bind = function(event, listener) {
 };
 
 /**
+ * Removes all listeners from a gamepad event.
+ * 
+ * @param {String} event Event to bind to, one of Gamepad.Event..
+ * @param {Function} listener Listener to call when given event occurs
+ * @return {Gamepad} Returns self
+ */
+Gamepad.prototype.unbind = function(event) {
+	this.listeners[event] = [];
+		
+	return this;
+};
+
+/**
  * Returns the number of connected gamepads.
  * 
  * @return {Number}


### PR DESCRIPTION
Right now events can have listeners bound to them, but they cannot be cleared of their listeners to allow for other use. This change adds an unbind function to Gamepad which removes all listeners from the given event. An unbindAll or clear function may also be a worthwhile addition.
